### PR TITLE
Fix link to paper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ devtools::install_github("constantAmateur/SoupX")
 
 ## Documentation
 
-The methodology implemented in this package is explained in detail in [this paper](https://github.com/constantAmateur/SoupX).  
+The methodology implemented in this package is explained in detail in [this paper](https://doi.org/10.1101/303727).  
 
 A detailed vignette is provided with the package and can be viewed [here](https://cdn.rawgit.com/constantAmateur/SoupX/master/inst/doc/pbmcTutorial.html).  
 


### PR DESCRIPTION
Instead of linking to the paper, the README refenced the github repository itself.
This commit fixes this by referencing the DOI of the SoupX pre-print instead.