### PR TITLE
Suggest formatR because of the chunk option tidy=TRUE in the vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Author: Matthew Daniel Young
 Maintainer: Matthew Daniel Young <my4@sanger.ac.uk>
 Description: Quantify, profile and remove ambient mRNA contamination (the "soup") from droplet based single cell RNA-seq experiments.  Implements the method described in Young et al. (2018) <doi:10.1101/303727>.
 URL: https://github.com/constantAmateur/SoupX
-Suggests: knitr, rstan, DropletUtils, rmarkdown
+Suggests: knitr, rstan, DropletUtils, rmarkdown, formatR
 VignetteBuilder: knitr
 Imports: ggplot2, Matrix, methods, Seurat
 Depends: R (>= 3.5.0)


### PR DESCRIPTION
This will fix the warnings about **formatR** on CRAN: https://cran.r-project.org/web/checks/check_results_SoupX.html which were caused by: https://github.com/constantAmateur/SoupX/blob/572a0cdaa1fe6d5573359d7f49342ed721947a5d/vignettes/pbmcTutorial.Rmd#L18